### PR TITLE
feat: 프로필 이미지 업로드 및 편집 기능 추가

### DIFF
--- a/src/actions/upload.ts
+++ b/src/actions/upload.ts
@@ -4,7 +4,7 @@
 // import { NextResponse } from 'next/server';
 
 export async function uploadImage(formData: FormData) {
-  const file = formData.get('imageFile') as File | null;
+  const file = formData.get('img') as File | null;
   const description = formData.get('description') as string | null;
 
   if (!file) {

--- a/src/features/play-link/view/sign-up/done.tsx
+++ b/src/features/play-link/view/sign-up/done.tsx
@@ -32,6 +32,8 @@ const Done = ({
         platform: infos.platform,
         device_id: infos.deviceId,
         device_type: infos.deviceType,
+        account_type: '0',
+        favor: '0',
         // prefer_sports: [1], // 배열 형태로 직접 전달
         img:
           allData.profileImage instanceof File

--- a/src/features/play-link/view/sign-up/step3.tsx
+++ b/src/features/play-link/view/sign-up/step3.tsx
@@ -191,6 +191,8 @@ export default function Step3({
       platform: infos.platform,
       device_id: infos.deviceId,
       device_type: infos.deviceType,
+      account_type: '0',
+      favor: '0',
       // prefer_sports: data.favoriteSports,
       img: imgFile,
     };

--- a/src/hooks/profile/use-update-profile-mutation.ts
+++ b/src/hooks/profile/use-update-profile-mutation.ts
@@ -10,5 +10,8 @@ export const useUpdateProfileMutation = () => {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.PROFILE] });
     },
+    onError: (error) => {
+      console.error('프로필 업데이트 실패:', error);
+    },
   });
 };

--- a/src/hooks/useSignup.ts
+++ b/src/hooks/useSignup.ts
@@ -13,6 +13,8 @@ interface SignupData {
   platform: string;
   device_id: string;
   device_type: string;
+  account_type: string;
+  favor: string;
   // prefer_sports: number[];
   img: File;
 }
@@ -33,6 +35,8 @@ const useSignup = () => {
     formData.append('platform', signupData.platform);
     formData.append('device_id', signupData.device_id);
     formData.append('device_type', signupData.device_type);
+    formData.append('account_type', signupData.account_type);
+    formData.append('favor', signupData.favor);
     // formData.append('prefer_sports', JSON.stringify(signupData.prefer_sports));
 
     // 파일이 있으면 추가

--- a/src/services/auth/auth.ts
+++ b/src/services/auth/auth.ts
@@ -16,6 +16,8 @@ interface SignUpType {
   platform: string;
   device_id: string;
   device_type: string;
+  account_type: string;
+  favor: string;
   // prefer_sports: number[];
   img: File;
 }
@@ -90,6 +92,8 @@ export const fetchSignUp = async (signupData: SignUpType) => {
   formData.append('platform', signupData.platform);
   formData.append('device_id', signupData.device_id);
   formData.append('device_type', signupData.device_type);
+  formData.append('account_type', '0');
+  formData.append('favor', '0');
   // formData.append('prefer_sports', JSON.stringify(signupData.prefer_sports));
 
   // 파일이 있으면 추가


### PR DESCRIPTION
- 이미지 선택 및 미리보기 기능 구현
- 프로필 업데이트 시 이미지 업로드 기능 추가
- 회원가입 및 프로필 관련 데이터 구조에 account_type 및 favor 필드 추가

회원가입 시 favor이라는 내용이 추가되어있어서 이것도 그냥 0으로 명시 해둠.
이미지도 같이 업데이트 진행하고, playlink-icon.png로 이미지를 넣었는데 db에는 기본 이미지가 들어가있는 상태,
기존 image 업데이트 로직은 잘 동작 함.